### PR TITLE
Update build tools to 26.0.2 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-26.0.1
+  - build-tools-26.0.2
   - android-26
 licenses:
  - android-sdk-license-.+


### PR DESCRIPTION
This should fix currently broken build (because of the licenses)