### PR TITLE
Supports Java 9 for building project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@ apply from: 'changelogs.gradle'
 
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.18'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,7 +13,6 @@ android {
     }
 
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
Allows to build the project on machine with Java 9 only by updating build tools and gradle wrapper.