### PR TITLE
Copy cached byte arrays values to prevent outer modifications

### DIFF
--- a/library/src/main/java/com/ironz/binaryprefs/serialization/strategy/impl/ByteArraySerializationStrategy.java
+++ b/library/src/main/java/com/ironz/binaryprefs/serialization/strategy/impl/ByteArraySerializationStrategy.java
@@ -4,13 +4,15 @@ import com.ironz.binaryprefs.serialization.SerializerFactory;
 import com.ironz.binaryprefs.serialization.serializer.ByteArraySerializer;
 import com.ironz.binaryprefs.serialization.strategy.SerializationStrategy;
 
+import java.util.Arrays;
+
 public final class ByteArraySerializationStrategy implements SerializationStrategy {
 
     private final byte[] value;
     private final ByteArraySerializer byteArraySerializer;
 
     public ByteArraySerializationStrategy(byte[] value, SerializerFactory serializerFactory) {
-        this.value = value;
+        this.value = Arrays.copyOf(value, value.length);
         this.byteArraySerializer = serializerFactory.getByteArraySerializer();
     }
 

--- a/library/src/test/java/com/ironz/binaryprefs/BinaryPreferencesTest.java
+++ b/library/src/test/java/com/ironz/binaryprefs/BinaryPreferencesTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -455,6 +456,24 @@ public final class BinaryPreferencesTest {
         byte[] restored = preferences.getByteArray(key, defaultValue);
 
         assertArrayEquals(value, restored);
+    }
+
+    @Test
+    public void byteArrayValue_cachedValueIsCopied() {
+        byte[] expected = new byte[]{1, 2, 3, 4, 5, 6, 7};
+
+        byte[] value = Arrays.copyOf(expected, expected.length);
+        byte[] defaultValue = {};
+
+        preferences.edit()
+            .putByteArray(key, value)
+            .apply();
+
+        value[0] = 13;
+
+        byte[] restored = preferences.getByteArray(key, defaultValue);
+
+        assertArrayEquals(expected, restored);
     }
 
     @Test


### PR DESCRIPTION
Cached byte arrays have to be copied.
Fix for issue #57 