### PR TITLE
Preferences operations succeed when thread is interrupted.

### DIFF
--- a/library/src/main/java/com/ironz/binaryprefs/task/FutureBarrier.java
+++ b/library/src/main/java/com/ironz/binaryprefs/task/FutureBarrier.java
@@ -23,7 +23,7 @@ public final class FutureBarrier<T> {
      */
     public void completeBlockingUnsafe() {
         try {
-            future.get();
+            Uninterruptibles.getUninterruptibly(future);
         } catch (Exception e) {
             throw new FileOperationException(e);
         }
@@ -34,7 +34,7 @@ public final class FutureBarrier<T> {
      */
     public T completeBlockingWihResult(T defValue) {
         try {
-            return future.get();
+            return Uninterruptibles.getUninterruptibly(future);
         } catch (Exception e) {
             exceptionHandler.handle(e);
         }
@@ -46,7 +46,7 @@ public final class FutureBarrier<T> {
      */
     public T completeBlockingWithResultUnsafe() {
         try {
-            return future.get();
+            return Uninterruptibles.getUninterruptibly(future);
         } catch (Exception e) {
             throw new FileOperationException(e);
         }
@@ -60,7 +60,7 @@ public final class FutureBarrier<T> {
      */
     public boolean completeBlockingWithStatus() {
         try {
-            future.get();
+            Uninterruptibles.getUninterruptibly(future);
             return true;
         } catch (Exception e) {
             exceptionHandler.handle(e);

--- a/library/src/main/java/com/ironz/binaryprefs/task/Uninterruptibles.java
+++ b/library/src/main/java/com/ironz/binaryprefs/task/Uninterruptibles.java
@@ -1,0 +1,35 @@
+package com.ironz.binaryprefs.task;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+final class Uninterruptibles {
+
+    private Uninterruptibles() {
+    }
+
+    /**
+     * Invokes {@link Future#get()} uninterruptibly.
+     *
+     * @throws ExecutionException    if the computation threw an exception
+     * @throws CancellationException if the computation was cancelled
+     */
+    static <V> V getUninterruptibly(Future<V> future) throws ExecutionException {
+        boolean interrupted = false;
+
+        try {
+            while (true) {
+                try {
+                    return future.get();
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/library/src/test/java/com/ironz/binaryprefs/BinaryPreferencesInterruptionTest.java
+++ b/library/src/test/java/com/ironz/binaryprefs/BinaryPreferencesInterruptionTest.java
@@ -1,0 +1,224 @@
+package com.ironz.binaryprefs;
+
+import com.ironz.binaryprefs.event.ExceptionHandler;
+import com.ironz.binaryprefs.file.directory.DirectoryProvider;
+import com.ironz.binaryprefs.task.TaskExecutor;
+import com.ironz.binaryprefs.task.TestNewSingleThreadTaskExecutor;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BinaryPreferencesInterruptionTest {
+
+    private static final String PREFERENCES_NAME = "user_preferences";
+    private static final String SECOND_PREFERENCES_NAME = "second_user_preferences";
+
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+    private static final String DEFAULT_VALUE = "defaultValue";
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private Preferences preferences;
+    private File srcDir;
+    private File backupDir;
+    private File lockDir;
+
+    @Before
+    public void setUp() throws Exception {
+        srcDir = folder.newFolder("preferences");
+        backupDir = folder.newFolder("backup");
+        lockDir = folder.newFolder("lock");
+
+        preferences = create(
+                PREFERENCES_NAME,
+                srcDir,
+                backupDir,
+                lockDir
+        );
+    }
+
+    @Test
+    public void commitSucceedsWhenThreadInterrupted() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().interrupt();
+
+                preferences.edit()
+                        .putString(KEY, VALUE)
+                        .commit();
+
+                assertEquals(VALUE, preferences.getString(KEY, DEFAULT_VALUE));
+                assertTrue(Thread.currentThread().isInterrupted());
+
+                latch.countDown();
+            }
+        });
+        thread.start();
+
+        awaitWithTimeout(latch);
+
+        assertEquals(VALUE, preferences.getString(KEY, DEFAULT_VALUE));
+    }
+
+    @Test
+    public void applySucceedsWhenThreadInterrupted() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().interrupt();
+
+                preferences.edit()
+                        .putString(KEY, VALUE)
+                        .apply();
+
+                assertEquals(VALUE, preferences.getString(KEY, DEFAULT_VALUE));
+                assertTrue(Thread.currentThread().isInterrupted());
+
+                latch.countDown();
+            }
+        });
+        thread.start();
+
+        awaitWithTimeout(latch);
+        assertEquals(VALUE, preferences.getString(KEY, DEFAULT_VALUE));
+    }
+
+    /**
+     * Getting the value from the same preferences which were user to set value.
+     * Preferences cache contains key value when getting value, thus "hot get".
+     */
+    @Test
+    public void hotGetSucceedsWhenThreadInterrupted() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        preferences.edit()
+                .putString(KEY, VALUE)
+                .apply();
+
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().interrupt();
+
+                assertEquals(VALUE, preferences.getString(KEY, DEFAULT_VALUE));
+                assertTrue(Thread.currentThread().isInterrupted());
+
+                latch.countDown();
+            }
+        });
+        thread.start();
+
+        awaitWithTimeout(latch);
+    }
+
+    /**
+     * Getting the value from the another preferences, which have the same dirs, but
+     * do not share cache with preferences user to set value.
+     * Preferences cache doesn't contain key value when getting value, thus "cold get".
+     */
+    @Test
+    public void coldGetSucceedsWhenThreadInterrupted() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        preferences.edit()
+                .putString(KEY, VALUE)
+                .commit();
+
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().interrupt();
+
+                // Preferences share same dirs, but don't share value cache,
+                // so getting a value required loading preferences from file.
+                final Preferences secondPreferences = create(SECOND_PREFERENCES_NAME,
+                        srcDir,
+                        backupDir,
+                        lockDir
+                );
+
+                assertEquals(VALUE, secondPreferences.getString(KEY, DEFAULT_VALUE));
+                assertTrue(Thread.currentThread().isInterrupted());
+
+                latch.countDown();
+            }
+        });
+        thread.start();
+
+        awaitWithTimeout(latch);
+    }
+
+    private static void awaitWithTimeout(CountDownLatch latch) throws InterruptedException {
+        final boolean inTime = latch.await(20, TimeUnit.SECONDS);
+        assertTrue(inTime);
+    }
+
+    private static Preferences create(String name,
+                                      final File srcDir,
+                                      final File backupDir,
+                                      final File lockDir) {
+
+        final DirectoryProvider directoryProvider = new DirectoryProvider() {
+            @Override
+            public File getStoreDirectory() {
+                return srcDir;
+            }
+
+            @Override
+            public File getBackupDirectory() {
+                return backupDir;
+            }
+
+            @Override
+            public File getLockDirectory() {
+                return lockDir;
+            }
+        };
+
+        final ExceptionHandler exceptionHandler = new ExceptionHandler() {
+            @Override
+            public void handle(Exception e) {
+                // Fail on all exceptions.
+                fail(e.toString());
+            }
+        };
+
+        // The executor shouldn't run tasks on current thread,
+        // so any tasks submitted to it won't fail once "current" thread is interrupted.
+        // For example, NIO operations would fail on interruption.
+        final TaskExecutor taskExecutor = new TestNewSingleThreadTaskExecutor(
+                exceptionHandler);
+
+        return new PreferencesCreator().create(
+                name,
+                directoryProvider,
+                new ConcurrentHashMap<String, ReadWriteLock>(),
+                new ConcurrentHashMap<String, Lock>(),
+                new ConcurrentHashMap<String, Set<String>>(),
+                new ConcurrentHashMap<String, Map<String, Object>>(),
+                taskExecutor
+        );
+    }
+}

--- a/library/src/test/java/com/ironz/binaryprefs/PreferencesCreator.java
+++ b/library/src/test/java/com/ironz/binaryprefs/PreferencesCreator.java
@@ -79,15 +79,35 @@ public final class PreferencesCreator {
                        Map<String, Lock> processLocks,
                        Map<String, Set<String>> allCacheCandidates,
                        Map<String, Map<String, Object>> allCaches) {
+
+        final ExceptionHandler exceptionHandler = ExceptionHandler.IGNORE;
+        final TaskExecutor taskExecutor = new TestTaskExecutor(exceptionHandler);
+
+        return create(
+                name,
+                directoryProvider,
+                locks,
+                processLocks,
+                allCacheCandidates,
+                allCaches,
+                taskExecutor
+        );
+    }
+
+    Preferences create(String name,
+                       DirectoryProvider directoryProvider,
+                       Map<String, ReadWriteLock> locks,
+                       Map<String, Lock> processLocks,
+                       Map<String, Set<String>> allCacheCandidates,
+                       Map<String, Map<String, Object>> allCaches,
+                       TaskExecutor taskExecutor) {
         FileAdapter fileAdapter = new NioFileAdapter(directoryProvider);
-        ExceptionHandler exceptionHandler = ExceptionHandler.IGNORE;
         LockFactory lockFactory = new SimpleLockFactory(name, directoryProvider, locks, processLocks);
         ValueEncryption valueEncryption = new AesValueEncryption("1111111111111111".getBytes(), "0000000000000000".getBytes());
         KeyEncryption keyEncryption = new XorKeyEncryption("1111111111111110".getBytes());
         FileTransaction fileTransaction = new MultiProcessTransaction(fileAdapter, lockFactory, keyEncryption, valueEncryption);
         CacheCandidateProvider candidateProvider = new ConcurrentCacheCandidateProvider(name, allCacheCandidates);
         CacheProvider cacheProvider = new ConcurrentCacheProvider(name, allCaches);
-        TaskExecutor taskExecutor = new TestTaskExecutor(exceptionHandler);
         PersistableRegistry persistableRegistry = new PersistableRegistry();
         persistableRegistry.register(TestUser.KEY, TestUser.class);
         SerializerFactory serializerFactory = new SerializerFactory(persistableRegistry);

--- a/library/src/test/java/com/ironz/binaryprefs/task/TestNewSingleThreadTaskExecutor.java
+++ b/library/src/test/java/com/ironz/binaryprefs/task/TestNewSingleThreadTaskExecutor.java
@@ -1,0 +1,36 @@
+package com.ironz.binaryprefs.task;
+
+import com.ironz.binaryprefs.event.ExceptionHandler;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Submits tasks on a single thread, which is not a current thread.
+ */
+public class TestNewSingleThreadTaskExecutor implements TaskExecutor {
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final ExceptionHandler exceptionHandler;
+
+    public TestNewSingleThreadTaskExecutor(ExceptionHandler exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public FutureBarrier<?> submit(Runnable runnable) {
+        return new FutureBarrier<>(
+                executor.submit(runnable),
+                exceptionHandler
+        );
+    }
+
+    @Override
+    public <T> FutureBarrier<T> submit(Callable<T> callable) {
+        return new FutureBarrier<>(
+                executor.submit(callable),
+                exceptionHandler
+        );
+    }
+}

--- a/library/src/test/java/com/ironz/binaryprefs/task/UninterruptiblesTest.java
+++ b/library/src/test/java/com/ironz/binaryprefs/task/UninterruptiblesTest.java
@@ -1,0 +1,251 @@
+package com.ironz.binaryprefs.task;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class UninterruptiblesTest {
+
+    // WORKING_SLEEP_DURATION_MILLIS < WAITING_SLEEP_TIMES * WAITING_SLEEP_DURATION_MILLIS
+    private static final long WORKING_SLEEP_DURATION_MILLIS = 500L;
+    private static final int WAITING_SLEEP_TIMES = 200;
+    private static final long WAITING_SLEEP_DURATION_MILLIS = 10L;
+
+    private static final String VALID_RESULT = "VALID_RESULT";
+    private static final String INTERRUPTED_RESULT = null;
+
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+        executor = null;
+    }
+
+    // region Latch - future is done once latch is count down
+    @Test
+    public void noInterruptsWithLatch() throws Exception {
+        nInterruptsWithLatch(0, 0);
+    }
+
+    @Test
+    public void singleInterruptWithLatch() throws Exception {
+        nInterruptsWithLatch(1, 0);
+    }
+
+    @Test
+    public void multipleInterruptsWithLatch() throws Exception {
+        nInterruptsWithLatch(100, 0);
+    }
+
+    @Test
+    public void multipleDelayedInterruptsWithLatch() throws Exception {
+        nInterruptsWithLatch(100, 10);
+    }
+
+    @Test
+    public void sanityCheck_plainFutureInterruptsWithLatch() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final Future<String> workingFuture = executor.submit(
+                new WorkingLatchCallable(latch));
+
+        final FutureTask<Boolean> waitingTask = new FutureTask<>(
+                new WaitingCallable(workingFuture, true));
+
+        final Thread waitingThread = new Thread(waitingTask);
+        waitingThread.start();
+        waitingThread.interrupt();
+
+        try {
+            waitingTask.get();
+            fail();
+        } catch (ExecutionException expected) {
+            // WaitingCallable must throw an InterruptedException
+            assertTrue(expected.getCause() instanceof InterruptedException);
+        }
+    }
+    // endregion Latch
+
+    // region Sleep - future is done once sleep finishes
+    @Test
+    public void noInterruptsWithSleep() throws Exception {
+        nInterruptsWithSleep(0, 0);
+    }
+
+    @Test
+    public void singleInterruptWithSleep() throws Exception {
+        nInterruptsWithSleep(1, 0);
+    }
+
+    @Test
+    public void multipleInterruptsWithSleep() throws Exception {
+        nInterruptsWithSleep(100, 0);
+    }
+
+    @Test
+    public void multipleDelayedInterruptsWithSleep() throws Exception {
+        nInterruptsWithSleep(WAITING_SLEEP_TIMES, WAITING_SLEEP_DURATION_MILLIS);
+    }
+
+    @Test
+    public void sanityCheck_plainFutureInterruptsWithSleep() throws Exception {
+        final Future<String> workingFuture = executor.submit(
+                new WorkingSleepCallable());
+
+        final FutureTask<Boolean> waitingTask = new FutureTask<>(
+                new WaitingCallable(workingFuture, true));
+
+        final Thread waitingThread = new Thread(waitingTask);
+        waitingThread.start();
+        waitingThread.interrupt();
+
+        try {
+            waitingTask.get();
+            fail();
+        } catch (ExecutionException expected) {
+            // WaitingCallable must throw an InterruptedException
+            assertTrue(expected.getCause() instanceof InterruptedException);
+        }
+    }
+    // endregion Sleep
+
+    private void nInterruptsWithLatch(int times,
+                                      long interruptDelayMillis) throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final Future<String> workingFuture = executor.submit(
+                new WorkingLatchCallable(latch));
+
+        final FutureTask<Boolean> waitingTask = new FutureTask<>(
+                new WaitingCallable(workingFuture, false));
+
+        final Thread waitingThread = new Thread(waitingTask);
+        waitingThread.start();
+
+        for (int i = 0; i < times; ++i) {
+            waitingThread.interrupt();
+
+            if (interruptDelayMillis > 0) {
+                Thread.sleep(interruptDelayMillis);
+            }
+        }
+
+        latch.countDown();
+
+        final boolean shouldWaitingBeInterrupted = times > 0;
+        final boolean wasWaitingInterrupted = waitingTask.get();
+        assertEquals(shouldWaitingBeInterrupted, wasWaitingInterrupted);
+    }
+
+    private void nInterruptsWithSleep(int times,
+                                      long interruptDelayMillis) throws Exception {
+        final Future<String> workingFuture = executor.submit(
+                new WorkingSleepCallable());
+
+        final FutureTask<Boolean> waitingTask = new FutureTask<>(
+                new WaitingCallable(workingFuture, false));
+
+        final Thread waitingThread = new Thread(waitingTask);
+        waitingThread.start();
+
+        for (int i = 0; i < times; ++i) {
+            waitingThread.interrupt();
+
+            if (interruptDelayMillis > 0) {
+                Thread.sleep(interruptDelayMillis);
+            }
+        }
+
+        final boolean shouldWaitingBeInterrupted = times > 0;
+        final boolean wasWaitingInterrupted = waitingTask.get();
+        assertEquals(shouldWaitingBeInterrupted, wasWaitingInterrupted);
+    }
+
+    /**
+     * Finishes once latch is released.
+     */
+    private static class WorkingLatchCallable implements Callable<String> {
+
+        private final CountDownLatch latch;
+
+        WorkingLatchCallable(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public String call() {
+            try {
+                latch.await();
+                return VALID_RESULT;
+            } catch (InterruptedException shouldNotHappen) {
+                fail();
+            }
+
+            return INTERRUPTED_RESULT;
+        }
+    }
+
+    /**
+     * Finishes after sleeping for {@link #WORKING_SLEEP_DURATION_MILLIS}.
+     */
+    private static class WorkingSleepCallable implements Callable<String> {
+
+        @Override
+        public String call() {
+            try {
+                Thread.sleep(WORKING_SLEEP_DURATION_MILLIS);
+                return VALID_RESULT;
+            } catch (InterruptedException shouldNotHappen) {
+                fail();
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Waits for working future to complete,
+     * returns thread interrupted status.
+     */
+    private static class WaitingCallable implements Callable<Boolean> {
+
+        private final Future<String> workingFuture;
+        private final boolean allowInterruption;
+
+        WaitingCallable(Future<String> workingFuture,
+                        boolean allowInterruption) {
+
+            this.workingFuture = workingFuture;
+            this.allowInterruption = allowInterruption;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+            final String result = allowInterruption
+                    ? workingFuture.get()
+                    : Uninterruptibles.getUninterruptibly(workingFuture);
+
+            assertEquals(VALID_RESULT, result);
+
+            return Thread.interrupted();
+        }
+    }
+}


### PR DESCRIPTION
FutureBarrier waits for Futures, which throw InterruptedException if thread is interrupted.
If such a case, the exception is passed to exception handler, while methods like "completeBlockingWihResult" return defaultValue instead of actual value. This causes inconvenience on library user's side: if thread is interrupted, the returned value is incorrect, and it's hard to detect that the exact call to get value returned an incorrect value.

In similar cases, the original SharedPreferencesImpl loops waiting for condition and swallowing any InterruptedExceptions, so it returns the actual value even if the thread is interrupted.

Getting the future uninterruptibly makes binaryprefs behavior closer to the behavior of original SharedPreferences.
However, while SharedPreferencesImpl simply swallows the InterruptedException, the "uninterruptible get" sets the interrupted status back to the thread.